### PR TITLE
Setup of the github workflow for testing with pytest.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,9 +21,12 @@ jobs:
             python-version: "3.9"
       - name: Build arc_omero
         run: |
-          python -m venv test_env
-          source test_env/bin/activate
           pip install --upgrade pip
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git"
           pip install ".[dev]"
-      - run:  echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - name: Run tests 
+        run:  |
+          pip install pytest
+          .omero/compose up
+      - name: Stop OMERO test database
+        run: ".omero/compose down"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,14 +8,13 @@ jobs:
     name: Run integration tests against OMERO
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout
       - name: Checkout omero-test-infra
-        uses: actions/checkout@mian
+        uses: actions/checkout@main
         with:
           repository: ome/omero-test-infra
           path: .omero
       - name: Set up Python
-        uses: actions/setup-python
+        uses: actions/setup-python@v4
         with:
             python-version: "3.8"
       - name: Build arc_omero

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           repository: ome/omero-test-infra
           path: .omero
+      - name: checkout arc_omero
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -21,7 +23,7 @@ jobs:
         run: |
           python -m venv test_env
           source test_env/bin/activate
-          pip install zeroc-ice
+          pip install --upgrade pip
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git"
           pip install ".[dev]"
       - run:  echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m venv test_env
           source test_env/bin/activate
+          pip install zeroc-ice
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git"
-          pip install .[dev]
+          pip install ".[dev]"
       - run:  echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,6 +15,19 @@ jobs:
           path: .omero
       - name: Launch OMERO test database
         run:  .omero/compose up -d
+        env:
+          ROOTPASS: omero
+          POSTGRES_IMAGE: postgres
+          POSTGRES_VERSION: 10
+          POSTGRES_PASSWORD: postgres
+          OMERO_SERVER_IMAGE: openmicroscopy/omero-server
+          OMERO_SERVER_VERSION: 5
+          OMERO_SERVER_TCP: "4063:"
+          OMERO_SERVER_SSL: "4064:"
+          OMERO_WEB_IMAGE: openmicroscopy/omero-web-standalone
+          OMERO_WEB_VERSION: 5
+          OMERO_WEB_PORT: "4080:"
+          BUILD_IMAGE: adoptopenjdk:11-jdk-hotspot-bionic
       - name: checkout arc_omero
         uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,11 +37,15 @@ jobs:
             cache: 'pip' # caching pip dependencies
       - name: Build arc_omero
         run: |
+          mkdir bftools
+          unzip -d ./bftools bftools.zip
+          wget https://downloads.openmicroscopy.org/bio-formats/7.2.0/artifacts/bftools.zip
           pip install --upgrade pip
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git@omero_arc_importer"
           pip install ".[dev]"
       - name: Import datasets
         run: |
+          export PATH=$(pwd)/bftools:$PATH
           omero login --user root --password omero localhost
           omero transfer prepare --plugin arc_omero test/data/arcs/Resolve/assays/ResolveMolecularCartography/dataset
           omero transfer unpack --folder test/data/arcs/Resolve/assays/ResolveMolecularCartography/dataset 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,28 @@
+name: OMERO
+on:
+  commit:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run integration tests against OMERO
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout
+      - name: Checkout omero-test-infra
+        uses: actions/checkout@master
+        with:
+          repository: ome/omero-test-infra
+          path: .omero
+      - name: Set up Python
+        uses: actions/setup-python
+         with:
+            python-version: "3.8"
+      - name: Build arc_omero
+        run: |
+          python -m venv test_env
+          source test_env/bin/activate
+          pip install "omero-cli-transfer @ git+https://github.com/ome/omero-cli-transfer@main"
+          pip install .[dev]
+      - run:  echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
           path: .omero
       - name: Set up Python
         uses: actions/setup-python
-         with:
+        with:
             python-version: "3.8"
       - name: Build arc_omero
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,11 +21,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
             python-version: "3.9"
+            cache: 'pip' # caching pip dependencies
       - name: Build arc_omero
         run: |
           pip install --upgrade pip
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git"
           pip install ".[dev]"
+      - name: Import datasets
+        run: |
+          omero login --user root --password omero localhost
+          omero transfer prepare --plugin arc_omero test/data/arcs/Resolve/assays/ResolveMolecularCartography/dataset
+          omero transfer unpack --folder test/data/arcs/Resolve/assays/ResolveMolecularCartography/dataset 
       - name: Run tests 
         run:  |
           pip install pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build arc_omero
         run: |
           pip install --upgrade pip
-          pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git"
+          pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git@omero_arc_importer"
           pip install ".[dev]"
       - name: Import datasets
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           repository: ome/omero-test-infra
           path: .omero
+      - name: Launch OMERO test database
+        run:  .omero/compose up -d
       - name: checkout arc_omero
         uses: actions/checkout@v3
       - name: Set up Python
@@ -27,6 +29,5 @@ jobs:
       - name: Run tests 
         run:  |
           pip install pytest
-          .omero/compose up
       - name: Stop OMERO test database
-        run: ".omero/compose down"
+        run: .omero/compose down

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Build arc_omero
         run: |
           wget https://downloads.openmicroscopy.org/bio-formats/7.2.0/artifacts/bftools.zip
-          mkdir bftools
-          unzip -d ./bftools bftools.zip
+          unzip bftools.zip
           pip install --upgrade pip
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git@omero_arc_importer"
           pip install ".[dev]"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run tests 
         run:  |
           pip install pytest
+          pytest -v
       - name: Checkout omero-test-infra
         uses: actions/checkout@main
         with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-            python-version: "3.8"
+            python-version: "3.9"
       - name: Build arc_omero
         run: |
           python -m venv test_env

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,6 +1,5 @@
 name: OMERO
 on:
-  commit:
   push:
   pull_request:
 
@@ -11,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout
       - name: Checkout omero-test-infra
-        uses: actions/checkout@master
+        uses: actions/checkout@mian
         with:
           repository: ome/omero-test-infra
           path: .omero
@@ -23,6 +22,6 @@ jobs:
         run: |
           python -m venv test_env
           source test_env/bin/activate
-          pip install "omero-cli-transfer @ git+https://github.com/ome/omero-cli-transfer@main"
+          pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git"
           pip install .[dev]
       - run:  echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,9 +37,9 @@ jobs:
             cache: 'pip' # caching pip dependencies
       - name: Build arc_omero
         run: |
+          wget https://downloads.openmicroscopy.org/bio-formats/7.2.0/artifacts/bftools.zip
           mkdir bftools
           unzip -d ./bftools bftools.zip
-          wget https://downloads.openmicroscopy.org/bio-formats/7.2.0/artifacts/bftools.zip
           pip install --upgrade pip
           pip install "omero-cli-transfer @ git+https://github.com/MicheleBortol/omero-cli-transfer.git@omero_arc_importer"
           pip install ".[dev]"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,5 +29,10 @@ jobs:
       - name: Run tests 
         run:  |
           pip install pytest
+      - name: Checkout omero-test-infra
+        uses: actions/checkout@main
+        with:
+          repository: ome/omero-test-infra
+          path: .omero
       - name: Stop OMERO test database
         run: .omero/compose down

--- a/test/test_unpack.py
+++ b/test/test_unpack.py
@@ -1,0 +1,6 @@
+# content of test_sample.py
+def func(x):
+    return x + 1
+
+def test_answer():
+    assert func(3) == 4


### PR DESCRIPTION
Setup of the github workflow for testing with pytest. It uses omero-test-infra (https://github.com/ome/omero-test-infra)  as a submodule to setput an omero instance and then installs omero-cli-transfer (https://github.com/MicheleBortol/omero-cli-transfer/tree/omero_arc_importer) with the arc_omero plugin and runs pytest on it.
